### PR TITLE
Add comment-based help for Get-SystemUptime

### DIFF
--- a/Get-SystemUptime.ps1
+++ b/Get-SystemUptime.ps1
@@ -1,3 +1,18 @@
+<#
+.SYNOPSIS
+Gets the time elapsed since the last system boot.
+
+.DESCRIPTION
+Retrieves the operating system's last boot time and calculates the days,
+hours, and minutes the system has been running.
+
+.EXAMPLE
+PS> Get-SystemUptime
+Returns an object showing the current system uptime and last boot time.
+
+.OUTPUTS
+PSCustomObject. Returns an object with Days, Hours, Minutes, and Since properties.
+#>
 function Get-SystemUptime {
     $OS = Get-CimInstance Win32_OperatingSystem
     $UpTime = (Get-Date) - $OS.LastBootUpTime


### PR DESCRIPTION
## Summary
- document Get-SystemUptime with comment-based help block

## Testing
- `pwsh -NoLogo -Command "Get-Host | Select-Object Version"` *(failed: command not found)*
- `apt-get install -y powershell` *(failed: Unable to locate package powershell)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a9d064b0832aaedd8cad9f0e1eb4