### PR TITLE
Add CmdletBinding and parameter block to Get-SystemUptime

### DIFF
--- a/Get-SystemUptime.ps1
+++ b/Get-SystemUptime.ps1
@@ -1,4 +1,10 @@
 function Get-SystemUptime {
+    [CmdletBinding()]
+    param(
+        [string[]]$ComputerName,
+        [Microsoft.Management.Infrastructure.CimSession[]]$CimSession
+    )
+
     $OS = Get-CimInstance Win32_OperatingSystem
     $UpTime = (Get-Date) - $OS.LastBootUpTime
 


### PR DESCRIPTION
## Summary
- Add CmdletBinding to Get-SystemUptime for advanced function behavior
- Introduce parameter block with ComputerName and CimSession placeholders

## Testing
- `pwsh -NoLogo -NoProfile -Command ". ./Get-SystemUptime.ps1; Get-SystemUptime | Format-List"` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a9aa55fc832ab9606b550670b03c