### PR TITLE
Limit CIM query to LastBootUpTime property

### DIFF
--- a/Get-SystemUptime.ps1
+++ b/Get-SystemUptime.ps1
@@ -1,5 +1,5 @@
 function Get-SystemUptime {
-    $OS = Get-CimInstance Win32_OperatingSystem
+    $OS = Get-CimInstance -ClassName Win32_OperatingSystem -Property LastBootUpTime
     $UpTime = (Get-Date) - $OS.LastBootUpTime
 
     [PSCustomObject]@{


### PR DESCRIPTION
## Summary
- Restrict `Get-SystemUptime` CIM query to only retrieve `LastBootUpTime` from `Win32_OperatingSystem`.

## Testing
- ⚠️ `pwsh -NoLogo -Command ". ./Get-SystemUptime.ps1; Get-SystemUptime"` (missing `Get-CimInstance` cmdlet in environment)


------
https://chatgpt.com/codex/tasks/task_e_68b0a9b60ee0832a91f8018dd94969cb